### PR TITLE
Adds inclusion for sys/resource.h

### DIFF
--- a/src/proxy.h
+++ b/src/proxy.h
@@ -20,6 +20,7 @@
 
 #include <pthread.h>
 #include <stdint.h>
+#include <sys/resource.h>
 #include <hiredis.h>
 #include "ae.h"
 #include "anet.h"


### PR DESCRIPTION
Otherwise making fails with unresolved `rlim_t` on CentOs variants at the very least.