### PR TITLE
Memory of proxy thread is initialized to 0

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1729,7 +1729,7 @@ static void printClusterConfiguration(redisCluster *cluster) {
 
 static proxyThread *createProxyThread(int index) {
     int is_first = (index == 0);
-    proxyThread *thread = zmalloc(sizeof(*thread));
+    proxyThread *thread = zcalloc(sizeof(*thread));
     if (thread == NULL) return NULL;
     thread->loop = NULL;
     if (pipe(thread->io) == -1) {


### PR DESCRIPTION
Proxy will coredump when `CLUSTER_ADDRESS` is not a redis cluster node.
> Redis Cluster Proxy v0.0.1
> Cluster Address: 127.0.0.1:6379
> [2020-01-10 14:25:11] Not listening to IPv6: unsupported
> Listening on port 10087
> [2020-01-10 14:25:11] Starting 8 threads...
> [2020-01-10 14:25:11] Creating thread 0...
> Fetching cluster configuration...
> Failed to retrieve cluster configuration.
> Cluster node 127.0.0.1:6379 replied with error:
> ERR This instance has cluster support disabled
> [2020-01-10 14:25:11] ERROR: Failed to fetch cluster configuration!
> Segmentation fault (core dumped)

There is stack trace.
> warning: Unable to find libthread_db matching inferior's thread library, thread debugging will not be available.
> Core was generated by `./src/redis-cluster-proxy -p 10087 --log-level debug 127.0.0.1 6379'.
> Program terminated with signal SIGSEGV, Segmentation fault.
> #0  listNext (iter=iter@entry=0x7ffc20ebb680) at adlist.c:235
> 235	            iter->next = current->next;
> (gdb) bt
> #0  listNext (iter=iter@entry=0x7ffc20ebb680) at adlist.c:235
> #1  0x0000000000410f61 in freeProxyThread (thread=0x639b40) at proxy.c:1599
> #2  0x0000000000407bfb in createProxyThread (index=0) at proxy.c:1495
> #3  initProxy () at proxy.c:1305
> #4  main (argc=<optimized out>, argv=<optimized out>) at proxy.c:3470

As the code shows, https://github.com/artix75/redis-cluster-proxy/blob/unstable/src/proxy.c#L1730. Some fields of thread are dirty because they are not initialized to 0. But there are some places to call  `freeProxyThread` when occur errors, such as, the instance has cluster support disabled. Core will be generated when to release unaccessed memory. I consider the easiest way is to initialize the memory, so that we don't need to handle multiple situations carefully.

It will `exit(1)` without  segmentation fault even if the instance has cluster support disabled.
> Redis Cluster Proxy v0.0.1
> Cluster Address: 127.0.0.1:6379
> [2020-01-10 14:57:40] Not listening to IPv6: unsupported
> Listening on port 10087
> [2020-01-10 14:57:40] Starting 8 threads...
> [2020-01-10 14:57:40] Creating thread 0...
> Fetching cluster configuration...
> Failed to retrieve cluster configuration.
> Cluster node 127.0.0.1:6379 replied with error:
> ERR This instance has cluster support disabled
> [2020-01-10 14:57:40] ERROR: Failed to fetch cluster configuration!
> [2020-01-10 14:57:40] Free cluster
> FATAL: failed to create thread 0.