### PR TITLE
Unix socket documented in proxy.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Listen on port 7888
 
 Listen on UNIX socket and disable TCP connections
 
-`./redis-cluster-proxy --unixsocket /path/to/proxy.socket 127.0.0.1:7000`
+`./redis-cluster-proxy --unixsocket /path/to/proxy.socket --port 0 127.0.0.1:7000`
 
 You can change the number of threads using the `--threads` option.
 

--- a/proxy.conf
+++ b/proxy.conf
@@ -30,6 +30,16 @@
 # from clients (default 7777)
 port 7777
 
+# Specify the path for the Unix socket that will be used to listen for
+# incoming connections. There is no default, so Redis Cluster Proxy won't
+# listen on a Unix socket when not specified.
+#
+# unixsocket /path/to/proxy.socket
+
+# Set the Unix socket file permissions (default 0)
+#
+# unixsocketperm 760
+
 # Set the number of threads.
 threads 8
 

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1478,7 +1478,7 @@ int parseOptions(int argc, char **argv) {
         else if (!strcmp("--dump-queues", arg))
             config.dump_queues = 1;
         else if (!strcmp(argv[i], "--unixsocket") && !lastarg)
-            config.unixsocket = argv[++i];
+            config.unixsocket = zstrdup(argv[++i]);
         else if (!strcmp(argv[i], "--unixsocketperm") && !lastarg) {
             errno = 0;
             config.unixsocketperm = (mode_t)strtol(argv[++i], NULL, 8);


### PR DESCRIPTION
In `README.md`, we should set `--port ` to 0 exactly if we disable tcp connections. 

I think we should support to config `unixsocket` options in  `proxy.conf` as expected, so `config.unixsocket` needs be copied from `argv[++i]` because `argv` will be freed when finish parsing `proxy.conf`.