### PR TITLE
Fix unix socket fd bug and make logs more correct

### DIFF
--- a/src/proxy.h
+++ b/src/proxy.h
@@ -102,7 +102,7 @@ typedef struct clientRequest {
 
 typedef struct {
     aeEventLoop *main_loop;
-    int fds[BINDADDR_MAX];
+    int fds[BINDADDR_MAX + 1];
     int fd_count;
     int unixsocket_fd;
     int tcp_backlog;


### PR DESCRIPTION
The last fd of `fds[BINDADDR_MAX]` in `redisClusterProxy` is reserved for unix socket, so we need one more. And other modifications make logs more correct.