### PR TITLE
Use format attribute for 'proxyLog' in GCC compiler

### DIFF
--- a/src/logger.h
+++ b/src/logger.h
@@ -45,6 +45,11 @@
 
 extern const char *redisProxyLogLevels[5];
 
+#ifdef __GNUC__
+void proxyLog(int level, const char* format, ...)
+    __attribute__((format(printf, 2, 3)));
+#else
 void proxyLog(int level, const char* format, ...);
+#endif
 
 #endif /* __REDIS_CLUSTER_PROXY_LOGGER_H__ */


### PR DESCRIPTION
I found some errors in `proxyLog`, but there is no error when compiling. So I add format attribute on `proxyLog`, and solve warnings or errors of `proxyLog`.