### PR TITLE
fix option '--max-clients'

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -32,7 +32,7 @@ void initConfig(void) {
     config.unixsocket = NULL;
     config.unixsocketperm = DEFAULT_UNIXSOCKETPERM;
     config.tcpkeepalive = DEFAULT_TCP_KEEPALIVE;
-    config.maxclients = DEFAULT_MAX_CLIENTS;
+    config.max_clients = DEFAULT_MAX_CLIENTS;
     config.num_threads = DEFAULT_THREADS;
     config.tcp_backlog = DEFAULT_TCP_BACKLOG;
     config.daemonize = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -54,7 +54,7 @@ typedef struct {
     int entry_points_count;
     redisClusterEntryPoint entry_points[MAX_ENTRY_POINTS];
     int tcpkeepalive;
-    int maxclients;
+    int max_clients;
     int num_threads;
     int tcp_backlog;
     int daemonize;

--- a/src/help.c
+++ b/src/help.c
@@ -78,7 +78,7 @@ const char *mainHelpString =
 "  -c <file>            Configuration file\n"
 "  -p, --port <port>    Port (default: %d). Use 0 in order to disable \n"
 "                       TCP connections at all\n"
-"  --maxclients <n>    Max clients (default: %d)\n"
+"  --max-clients <n>    Max clients (default: %d)\n"
 "  --threads <n>        Thread number (default: %d, max: %d)\n"
 "  --tcpkeepalive       TCP Keep Alive (default: %d)\n"
 "  --tcp-backlog        TCP Backlog (default: %d)\n"


### PR DESCRIPTION
### before
```shell
[root@localhost redis]# ./src/redis-cluster-proxy --max-clients 10000 127.0.0.1:7000
Invalid option '--max-clients' or invalid number of option arguments

......
```
### after
```shell
[root@localhost redis]# ./src/redis-cluster-proxy --max-clients 10000 127.0.0.1:7000
[2020-04-23 15:35:24.828/M] Redis Cluster Proxy v999.999.999 (unstable)
[2020-04-23 15:35:24.829/M] Commit: (cf40f0b4/0)
[2020-04-23 15:35:24.829/M] Git Branch: unstable
[2020-04-23 15:35:24.829/M] PID: 55016
[2020-04-23 15:35:24.829/M] OS: Linux 3.10.0-862.11.6.el7.x86_64 x86_64
[2020-04-23 15:35:24.829/M] Bits: 64
[2020-04-23 15:35:24.829/M] Log level: info
[2020-04-23 15:35:24.829/M] Connections pool size: 10 (respawn 2 every 50ms if below 10)
[2020-04-23 15:35:24.830/M] Listening on *:7777
[2020-04-23 15:35:24.830/M] Starting 8 threads...
[2020-04-23 15:35:24.830/M] Fetching cluster configuration...
[2020-04-23 15:35:24.833/M] Cluster Address: 127.0.0.1:7000
[2020-04-23 15:35:24.833/M] Cluster has 3 masters and 3 replica(s)
[2020-04-23 15:35:24.871/M] All thread(s) started!
```