### PR TITLE
fix bug of evalGetKeys last_key assignment

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -1631,7 +1631,7 @@ int evalGetKeys(void *r, int *first_key, int *last_key, int *key_step,
     sds numkeys_s = sdsnewlen(req->buffer + req->offsets[2], req->lengths[2]);
     numkeys = atoi(numkeys_s);
     *first_key = 3;
-    *last_key = 3 + numkeys;
+    *last_key = numkeys == 0 ? 3 : (2 + numkeys);
     *key_step = 1;
     sdsfree(numkeys_s);
     return numkeys;


### PR DESCRIPTION
127.0.0.1:7777> eval "return KEYS[1]" 1 KEY1 ARGV1
(error) ERR Cross-slot queries are not supported for this command
127.0.0.1:7777> quit

There is an issue of  evalGetKeys last_key assignment, it will not working correctly when with arguments in eval command.