### PR TITLE
Fix crash in proxy cluster update

### DIFF
--- a/test/tests/proxy_command.rb
+++ b/test/tests/proxy_command.rb
@@ -5,7 +5,7 @@ test "PROXY CONFIG GET" do
         'threads' => 8,
         #'max-clients' => 10000
     }
-    conf.each{|opt, val| 
+    conf.each{|opt, val|
         reply = $main_proxy.proxy('config', 'get', opt.to_s)
         assert_not_redis_err(reply)
         assert(reply.is_a?(Array), "Expected array reply, got #{reply.class}")
@@ -21,4 +21,33 @@ test "LOG TO PROXY" do
     assert_not_redis_err reply
     log = File.read $main_proxy.logfile
     assert_not_nil(log[msg], "Could not find logged message in proxy's log")
+end
+
+test "PROXY CLUSTER INFO" do
+    reply = $main_proxy.proxy('cluster', 'info')
+    assert_not_redis_err(reply)
+    assert(reply.is_a?(Array), "Expected array reply, got #{reply.class}")
+    assert(reply[0..4] == ["status", "updated", "connection", "shared", "nodes"], "Got unexpected reply: #{reply}")
+    reply[5].each{ |node|
+        _, name, _, ip, _, port, _, slots, _, replicas, _, connected = node
+        assert(ip == "127.0.0.1", "unexpected ip #{ip}")
+        assert([18000, 18001, 18002, 18003, 18004, 18005].include?(port), "unexpected port #{port}")
+        assert([5461, 5462].include?(slots), "unexpected slots #{slots}")
+        assert(replicas == 1, "replicas of #{replicas} != 1")
+        assert(connected == 1, "connected of #{connected} != 1")
+    }
+end
+
+test "PROXY CLUSTER UPDATE" do
+    info_before = $main_proxy.proxy('cluster', 'info')
+    assert_not_redis_err(info_before)
+
+    update_reply = $main_proxy.proxy('cluster', 'update')
+    assert_not_redis_err(update_reply)
+
+    info_after = $main_proxy.proxy('cluster', 'info')
+    assert_not_redis_err(info_after)
+
+    assert(info_before == info_after, "cluster info before update != cluster info after update.\n #{info_before} != #{info_after}")
+
 end


### PR DESCRIPTION
Fixes #66

The problem appears to be that `resetCluster` does not null `cluster->master_names`, resulting in a double free when `proxy cluster update` is called twice.

Calling `clusterGetMasterNames` was not strictly necessary but it seemed like the right thing to do to ensure the cluster struct is fully recreated by the update.
